### PR TITLE
Added countdown and seed generation functions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 venv
 .idea
+.vscode/
 *.pyc
 *.pem
 *.ppk

--- a/curry_bot.py
+++ b/curry_bot.py
@@ -7,12 +7,14 @@ from discord_tools.discord_formatting import *
 from speedrunapi.speedrunapi import *
 
 import re
+import time
 
 
 TOKEN = get_token()
 RANDO_LINKS = ['https://adrando.com/']
 client = Bot(command_prefix='!', status=Status.online, activity=Game("Azure Dreams"))
 BOT_ID = '631144975366619146'
+COUNTDOWN_START = 10
 
 # EMOJIS
 NICOHEY = '<:NicoHey:635538084062298122>'
@@ -114,5 +116,21 @@ async def leaderboard(ctx, *args):
                 timestamp = '{}s'.format(secs)
 
             await ctx.send(curry_message("Rank: {}\tRunner: {}\t\tTime: {}".format(rank, player, timestamp)))
+
+@client.command(description="Type '!countdown' to start a countdown from {}. Type '!countdown <start>' to countdown from start, where start is a positive integer <= {}.".format(COUNTDOWN_START, COUNTDOWN_START), brief="Start a countdown")
+async def countdown(ctx, *args):
+    if args and not args[0].isdigit():
+        await ctx.send(curry_message("I can't count starting from {}. Curry.".format(args[0])))
+    else:
+        start = int(args[0]) if args else COUNTDOWN_START
+        if start <= 0:
+            await ctx.send(curry_message("Why not just say 'go'? Curry."))
+        elif start > COUNTDOWN_START:
+            await ctx.send(curry_message("That sounds like a lot of work. Ask me to start counting from {} or less. Curry.".format(COUNTDOWN_START)))
+        else:
+            for n in range(0, start):
+                await ctx.send(curry_message("{}".format(start - n)))
+                time.sleep(1)
+            await ctx.send(curry_message("Go! Curry."))
 
 client.run(TOKEN)


### PR DESCRIPTION
Added a `!countdown` command to give a countdown to help with races.
`!countdown` uses a default countdown of 10 seconds, and `!countdown <start>` counts down from `start`, where `start` is between 1 and 10 inclusive. I made sure to set that upper bound to not let some troll type `!countdown 999999`.

Added `!rando preset` nested command to list available presets for generating rando seeds.

Added `!rando <preset>` command, which generates three seeds with the given preset. The command accepts unique, partial matches for preset names (e.g. 'star" as a shorthand for 'starsTournament').

To avoid confusion if someone types `!rando <invalidPreset>`, the command `!rando <seed>` now validates that the first seed begins with https://adrando.com. If the validation fails, CurryBot explicitly states that seeds were not generated, does not update the seeds, and does not print the list of current seeds.

I've successfully tested all of the scenarios in my personal test discord.