### PR TITLE
Fixed output of '!rando preset' and more

### DIFF
--- a/discord_tools/discord_formatting.py
+++ b/discord_tools/discord_formatting.py
@@ -10,5 +10,9 @@ def curry_message(s):
     return ":curry: " + s
 
 
+def curry_format(s, *args):
+    return curry_message(s.format(*args))
+
+
 def get_author(message):
     return str(message.author)[:str(message.author).find('#')]


### PR DESCRIPTION
Fixed output of '!rando preset'. The limit on the number of seeds to generate printed in response to a excessive user-provided quantity has been corrected. Rando seed links are now sent in a single message to avoid throttling. Providing an invalid number of seed links to generate longer generates a default number of seeds.